### PR TITLE
53 infeasible scip

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.11 (problem-machine-scheduling)" />
+  </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (problem-machine-scheduling)" project-jdk-type="Python SDK" />
 </project>

--- a/problem_mop.py
+++ b/problem_mop.py
@@ -1,6 +1,7 @@
 import json
 import os
 import os.path
+import sys
 from typing import List, Tuple
 
 from jsonschema import validate
@@ -52,7 +53,8 @@ def evaluation(
         problem = f.readlines()
         problem = [row.split() for row in problem]
 
-    margin, xi, psiP, zP = 0.0, 0.0, 0.0, 0.0
+    fmax = [sys.float_info.max for _ in range(4)]
+    margin, xi, psiP, zP = fmax
 
     if os.path.isfile(sol_file):
         with open(sol_file, "r") as f:

--- a/problem_mop.py
+++ b/problem_mop.py
@@ -19,7 +19,7 @@ def evaluation(
         timeout: int,
         problem_file: str,
         jig_file: str
-) -> Tuple[List[float], float]:
+) -> Tuple[List[float] | None, float]:
     """SCIPを起動して評価値を計算する。
 
     Parameters
@@ -59,6 +59,9 @@ def evaluation(
     if os.path.isfile(sol_file):
         with open(sol_file, "r") as f:
             data = f.readlines()
+        if data[0] == "solution status: infeasible\n":  # 実行不能
+            os.remove(sol_file)
+            return None, exe_time
         tf_sum = 0.0  # 各ワークの納品時刻の合計値
         tfs = []  # 各ワークの納品時刻変数名リスト
         dead_sum = 0  # 納期の合計値


### PR DESCRIPTION
https://github.com/opthub-org/problem-machine-scheduling/issues/53#issue-2021787982
より引用

- SCIPは動いているので評価回数や計算時間を消費する
- 実行不可能な場合，soutionファイルにその旨が書き込まれる
- 実行不可能な場合は，`objective`を`null`にしてearly return
    - 今使っているindicatorは`null`の場合HVを計算しないので，とりあえずこれでOK